### PR TITLE
[CMake] Add minimal cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostContainerHash LANGUAGES CXX)
+
+add_library(boost_container_hash INTERFACE)
+add_library(Boost::container_hash ALIAS boost_container_hash)
+
+target_include_directories(boost_container_hash INTERFACE include)
+
+target_link_libraries(boost_container_hash
+    INTERFACE
+        Boost::assert
+        Boost::config
+        Boost::core
+        Boost::detail
+        Boost::integer
+        Boost::static_assert
+        Boost::type_traits
+)
+


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling

    add_subdirectory( <path-to-boost_container_hash> )
    target_link_libraries( <my_lib> PUBLIC Boost::container_hash )

More information:

- https://groups.google.com/forum/#!topic/boost-developers-archive/kM4JRmyVl3M%5B1-25%5D
- https://groups.google.com/d/msg/boost-developers-archive/4HU-RzReL7U/FS1X6OFrEQAJ

Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.