### PR TITLE
Removed usage of std::unary_function for C++17 compliance

### DIFF
--- a/include/boost/container_hash/hash.hpp
+++ b/include/boost/container_hash/hash.hpp
@@ -119,7 +119,11 @@ namespace boost
 {
     namespace hash_detail
     {
+<<<<<<< HEAD
 #if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC || defined(BOOST_NO_CXX98_FUNCTION_BASE)
+=======
+#if defined(BOOST_NO_CXX98_FUNCTION_BASE)
+>>>>>>> Removed usage of std::unary_function for C++17 compliance
         template <typename T>
         struct hash_base
         {

--- a/include/boost/container_hash/hash.hpp
+++ b/include/boost/container_hash/hash.hpp
@@ -119,7 +119,7 @@ namespace boost
 {
     namespace hash_detail
     {
-#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC
+#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC || defined(BOOST_NO_CXX98_FUNCTION_BASE)
         template <typename T>
         struct hash_base
         {

--- a/include/boost/container_hash/hash.hpp
+++ b/include/boost/container_hash/hash.hpp
@@ -119,11 +119,7 @@ namespace boost
 {
     namespace hash_detail
     {
-<<<<<<< HEAD
-#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC || defined(BOOST_NO_CXX98_FUNCTION_BASE)
-=======
 #if defined(BOOST_NO_CXX98_FUNCTION_BASE)
->>>>>>> Removed usage of std::unary_function for C++17 compliance
         template <typename T>
         struct hash_base
         {


### PR DESCRIPTION
Just to be able to compile boost with projects that uses C++17.