### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/container_hash/hash.hpp
+++ b/include/boost/container_hash/hash.hpp
@@ -442,7 +442,7 @@ namespace boost
         }
     }
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))
     template <class T>
     inline std::size_t hash_range(T* first, T* last)
     {

--- a/include/boost/container_hash/hash_fwd.hpp
+++ b/include/boost/container_hash/hash_fwd.hpp
@@ -27,7 +27,7 @@ namespace boost
     template <class It> std::size_t hash_range(It, It);
     template <class It> void hash_range(std::size_t&, It, It);
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))
     template <class T> inline std::size_t hash_range(T*, T*);
     template <class T> inline void hash_range(std::size_t&, T*, T*);
 #endif

--- a/test/hash_float_test.hpp
+++ b/test/hash_float_test.hpp
@@ -91,7 +91,7 @@ void float_tests(char const* name, T* = 0)
     using namespace std;
 
 // Doing anything with infinity causes borland to crash.
-#if defined(__BORLANDC__)
+#if defined(BOOST_BORLANDC)
     std::cerr
         <<  "Not running infinity checks on Borland, as it causes it to crash."
             "\n";
@@ -292,7 +292,7 @@ void float_tests(char const* name, T* = 0)
     }
 
 // NaN also causes borland to crash.
-#if !defined(__BORLANDC__) && defined(BOOST_HASH_TEST_EXTENSIONS)
+#if !defined(BOOST_BORLANDC) && defined(BOOST_HASH_TEST_EXTENSIONS)
     if(boost::hash_detail::limits<T>::has_quiet_NaN) {
         if(x1(boost::hash_detail::limits<T>::quiet_NaN()) == x1(1.0)) {
             std::cerr<<"x1(quiet_NaN) == x1(1.0) == "<<x1(1.0)<<"\n";


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.