### PR TITLE
Remove use of non-existant Boost.Config macro BOOST_NO_CXX11_HDR_MEMORY

### DIFF
--- a/include/boost/container_hash/extensions.hpp
+++ b/include/boost/container_hash/extensions.hpp
@@ -31,9 +31,7 @@
 #   include <tuple>
 #endif
 
-#if !defined(BOOST_NO_CXX11_HDR_MEMORY)
-#   include <memory>
-#endif
+#include <memory>
 
 #if defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
 #include <boost/type_traits/is_array.hpp>


### PR DESCRIPTION
Thanks to Jeff Trull for the catch.