### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,18 +5,21 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/describe//boost_describe
+    /boost/mp11//boost_mp11 ;
+
 project /boost/container_hash
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/describe//boost_describe
-        <library>/boost/mp11//boost_mp11
         <include>include
     ;
 
 explicit
-    [ alias boost_container_hash ]
+    [ alias boost_container_hash : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_container_hash examples test ]
     ;
 
 call-if : boost-library container_hash
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,10 +7,10 @@ import project ;
 
 project /boost/container_hash
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/describe//boost_describe
-        <source>/boost/mp11//boost_mp11
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/describe//boost_describe
+        <library>/boost/mp11//boost_mp11
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/container_hash

--- a/build.jam
+++ b/build.jam
@@ -12,7 +12,6 @@ project /boost/container_hash
         <library>/boost/config//boost_config
         <library>/boost/describe//boost_describe
         <library>/boost/mp11//boost_mp11
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,23 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/container_hash
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/describe//boost_describe
+        <source>/boost/mp11//boost_mp11
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_container_hash ]
+    [ alias all : boost_container_hash examples test ]
+    ;
+
+call-if : boost-library container_hash
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/container_hash
     : common-requirements

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -3,6 +3,8 @@
 # subject to the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import testing ;
+
 run books.cpp ;
 run point.cpp ;
 run portable.cpp ;

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -6,5 +6,5 @@
 run books.cpp ;
 run point.cpp ;
 run portable.cpp ;
-run template.cpp : : : <toolset>msvc-8.0:<build>no ;
+run template.cpp /boost/unordered//boost_unordered : : : <toolset>msvc-8.0:<build>no ;
 run point2.cpp ;

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -5,6 +5,8 @@
 
 import testing ;
 
+project : requirements <library>/boost/container_hash//boost_container_hash ;
+
 run books.cpp ;
 run point.cpp ;
 run portable.cpp ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,6 +10,8 @@ local clang-flags = $(gcc-flags) -Wno-c99-extensions ;
 
 project hash-tests
     : requirements
+        <source>/boost/core//boost_core
+
         <warnings>pedantic
         <toolset>intel:<warnings>on
         <toolset>gcc:<cxxflags>$(gcc-flags)
@@ -72,16 +74,16 @@ run quick.cpp ;
 
 run hash_number_test2.cpp ;
 run hash_integral_test.cpp ;
-run hash_string_test2.cpp ;
+run hash_string_test2.cpp /boost/utility//boost_utility ;
 
 # for gcc-4.8
 local fs-path-req = "-<toolset>gcc:<cxxflags>-Wshadow" "-<toolset>gcc:<cxxflags>-Wconversion" <toolset>gcc-4.7:<build>no ;
 
-run hash_fs_path_test.cpp /boost//filesystem/<warnings>off : : : $(fs-path-req)
+run hash_fs_path_test.cpp /boost/filesystem//boost_filesystem/<warnings>off : : : $(fs-path-req)
   <toolset>msvc-14.0,<cxxstd>latest:<build>no
   <undefined-sanitizer>norecover:<link>static ;
 
-run is_range_test2.cpp : : : $(fs-path-req) ;
+run is_range_test2.cpp /boost/filesystem//boost_filesystem : : : $(fs-path-req) ;
 
 run hash_container_test.cpp ;
 
@@ -116,8 +118,8 @@ run is_described_class_test3.cpp
 run described_class_test.cpp
   : : : <warnings>extra ;
 
-run hash_is_avalanching_test.cpp ;
-run hash_is_avalanching_test2.cpp ;
+run hash_is_avalanching_test.cpp /boost/unordered//boost_unordered ;
+run hash_is_avalanching_test2.cpp /boost/unordered//boost_unordered ;
 
 run hash_integral_test2.cpp ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,6 +10,7 @@ local clang-flags = $(gcc-flags) -Wno-c99-extensions ;
 
 project hash-tests
     : requirements
+        <library>/boost/container_hash//boost_container_hash
         <library>/boost/core//boost_core
         <library>/boost/type_traits//boost_type_traits
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,7 +10,8 @@ local clang-flags = $(gcc-flags) -Wno-c99-extensions ;
 
 project hash-tests
     : requirements
-        <source>/boost/core//boost_core
+        <library>/boost/core//boost_core
+        <library>/boost/type_traits//boost_type_traits
 
         <warnings>pedantic
         <toolset>intel:<warnings>on


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.