### PR TITLE
Feature/hash_is_avalanching

### DIFF
--- a/doc/hash/changes.adoc
+++ b/doc/hash/changes.adoc
@@ -12,9 +12,6 @@ https://www.boost.org/LICENSE_1_0.txt
 
 :int128: __int128
 
-== Boost 1.89.0
-* Added the `hash_is_avalanching` trait class.
-
 == Boost 1.67.0
 * Moved library into its own module, `container_hash`.
 * Moved headers for new module name, now at: `<boost/container_hash/hash.hpp>`, `<boost/container_hash/hash_fwd.hpp>`, `<boost/container_hash/extensions.hpp>`.

--- a/doc/hash/changes.adoc
+++ b/doc/hash/changes.adoc
@@ -12,6 +12,9 @@ https://www.boost.org/LICENSE_1_0.txt
 
 :int128: __int128
 
+== Boost 1.89.0
+* Added the `hash_is_avalanching` trait class.
+
 == Boost 1.67.0
 * Moved library into its own module, `container_hash`.
 * Moved headers for new module name, now at: `<boost/container_hash/hash.hpp>`, `<boost/container_hash/hash_fwd.hpp>`, `<boost/container_hash/extensions.hpp>`.

--- a/doc/hash/recent.adoc
+++ b/doc/hash/recent.adoc
@@ -8,6 +8,10 @@ https://www.boost.org/LICENSE_1_0.txt
 = Recent Changes
 :idprefix: recent_
 
+== Boost 1.89.0
+
+* Added the `hash_is_avalanching` trait class.
+
 == Boost 1.84.0
 
 * {cpp}03 is no longer supported.

--- a/doc/hash/reference.adoc
+++ b/doc/hash/reference.adoc
@@ -618,7 +618,7 @@ to determine if the supplied hash function is of high quality.
 `boost::hash` for `std::basic_string<Ch>` and `std::basic_string_view<Ch>`
 has this trait set to `true` when `Ch` is an integral type (this includes
 `std::string` and `std::string_view`, among others).
-Users can set this this trait for a particular `Hash` type by:
+Users can set this trait for a particular `Hash` type by:
 
 * Inserting the nested `is_avalanching` typedef in the class definition
 if they have access to its source code. 

--- a/doc/hash/reference.adoc
+++ b/doc/hash/reference.adoc
@@ -1,7 +1,7 @@
 ////
 Copyright 2005-2008 Daniel James
 Copyright 2022 Christian Mazakas
-Copyright 2022 Peter Dimov
+Copyright 2022, 2025 Peter Dimov
 Distributed under the Boost Software License, Version 1.0.
 https://www.boost.org/LICENSE_1_0.txt
 ////
@@ -26,6 +26,7 @@ namespace boost
 namespace container_hash
 {
 
+template<class Hash> struct hash_is_avalanching;
 template<class T> struct is_range;
 template<class T> struct is_contiguous_range;
 template<class T> struct is_unordered_range;
@@ -571,6 +572,61 @@ where `x` is the currently contained value in `v`.
 
 Throws: ::
 `std::bad_variant_access` when `v.valueless_by_exception()` is `true`.
+
+== <boost/container_hash/{zwsp}hash_is_avalanching.hpp>
+
+Defines the trait `boost::container_hash::hash_is_avalanching`.
+
+[source]
+----
+namespace boost
+{
+
+namespace container_hash
+{
+
+template<class Hash> struct hash_is_avalanching;
+
+} // namespace container_hash
+
+} // namespace boost
+----
+
+=== hash_is_avalanching<Hash>
+
+[source]
+----
+template<class Hash> struct hash_is_avalanching
+{
+    static constexpr bool value = /* see below */;
+};
+----
+
+`hash_is_avalanching<Hash>::value` is:
+
+* `false` if `Hash::is_avalanching` is not present,
+* `Hash::is_avalanching::value` if this is present and convertible at compile time to a `bool`,
+* `true` if `Hash::is_avalanching` is `void` (this usage is deprecated),
+* ill-formed otherwise.
+
+A hash function is said to have the _avalanching property_ if small changes
+in the input translate to large changes in the returned hash code
+&#8212;ideally, flipping one bit in the representation of the input value results
+in each bit of the hash code flipping with probability 50%. Libraries
+such as link:../../../unordered/index.html[Boost.Unordered] consult this trait
+to determine if the supplied hash function is of high quality. 
+`boost::hash` for `std::basic_string<Ch>` and `std::basic_string_view<Ch>`
+has this trait set to `true` when `Ch` is an integral type (this includes
+`std::string` and `std::string_view`, among others).
+Users can set this this trait for a particular `Hash` type by:
+
+* Inserting the nested `is_avalanching` typedef in the class definition
+if they have access to its source code. 
+* Writing a specialization of `boost::container_hash::hash_is_avalanching`
+for `Hash`.
+
+Note that usage of this trait is not restricted to hash functions produced
+with Boost.ContainerHash.
 
 == <boost/container_hash/{zwsp}is_range.hpp>
 

--- a/doc/hash/reference.adoc
+++ b/doc/hash/reference.adoc
@@ -26,7 +26,6 @@ namespace boost
 namespace container_hash
 {
 
-template<class Hash> struct hash_is_avalanching;
 template<class T> struct is_range;
 template<class T> struct is_contiguous_range;
 template<class T> struct is_unordered_range;
@@ -44,6 +43,8 @@ template<class It> std::size_t hash_range( It first, It last );
 
 template<class It> void hash_unordered_range( std::size_t& seed, It first, It last );
 template<class It> std::size_t hash_unordered_range( It first, It last );
+
+template<class Hash> struct hash_is_avalanching;
 
 } // namespace boost
 ----
@@ -575,19 +576,14 @@ Throws: ::
 
 == <boost/container_hash/{zwsp}hash_is_avalanching.hpp>
 
-Defines the trait `boost::container_hash::hash_is_avalanching`.
+Defines the trait `boost::hash_is_avalanching`.
 
 [source]
 ----
 namespace boost
 {
 
-namespace container_hash
-{
-
 template<class Hash> struct hash_is_avalanching;
-
-} // namespace container_hash
 
 } // namespace boost
 ----
@@ -622,7 +618,7 @@ Users can set this trait for a particular `Hash` type by:
 
 * Inserting the nested `is_avalanching` typedef in the class definition
 if they have access to its source code. 
-* Writing a specialization of `boost::container_hash::hash_is_avalanching`
+* Writing a specialization of `boost::hash_is_avalanching`
 for `Hash`.
 
 Note that usage of this trait is not restricted to hash functions produced

--- a/include/boost/container_hash/hash.hpp
+++ b/include/boost/container_hash/hash.hpp
@@ -560,16 +560,13 @@ namespace boost
 
     // hash_is_avalanching
 
-    namespace container_hash
-    {
-        template<class Ch> struct hash_is_avalanching< boost::hash< std::basic_string<Ch> > >: std::is_integral<Ch> {};
+    template<class Ch> struct hash_is_avalanching< boost::hash< std::basic_string<Ch> > >: std::is_integral<Ch> {};
 
 #if !defined(BOOST_NO_CXX17_HDR_STRING_VIEW)
 
-        template<class Ch> struct hash_is_avalanching< boost::hash< std::basic_string_view<Ch> > >: std::is_integral<Ch> {};
+    template<class Ch> struct hash_is_avalanching< boost::hash< std::basic_string_view<Ch> > >: std::is_integral<Ch> {};
 
 #endif
-    } // namespace container_hash
 
 } // namespace boost
 

--- a/include/boost/container_hash/hash.hpp
+++ b/include/boost/container_hash/hash.hpp
@@ -1,5 +1,5 @@
 // Copyright 2005-2014 Daniel James.
-// Copyright 2021, 2022 Peter Dimov.
+// Copyright 2021, 2022, 2025 Peter Dimov.
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -11,6 +11,7 @@
 #define BOOST_FUNCTIONAL_HASH_HASH_HPP
 
 #include <boost/container_hash/hash_fwd.hpp>
+#include <boost/container_hash/hash_is_avalanching.hpp>
 #include <boost/container_hash/is_range.hpp>
 #include <boost/container_hash/is_contiguous_range.hpp>
 #include <boost/container_hash/is_unordered_range.hpp>
@@ -557,11 +558,10 @@ namespace boost
 
 #endif
 
-    // boost::unordered::hash_is_avalanching
+    // hash_is_avalanching
 
-    namespace unordered
+    namespace container_hash
     {
-        template<class T> struct hash_is_avalanching;
         template<class Ch> struct hash_is_avalanching< boost::hash< std::basic_string<Ch> > >: std::is_integral<Ch> {};
 
 #if !defined(BOOST_NO_CXX17_HDR_STRING_VIEW)
@@ -569,7 +569,7 @@ namespace boost
         template<class Ch> struct hash_is_avalanching< boost::hash< std::basic_string_view<Ch> > >: std::is_integral<Ch> {};
 
 #endif
-    } // namespace unordered
+    } // namespace container_hash
 
 } // namespace boost
 

--- a/include/boost/container_hash/hash_fwd.hpp
+++ b/include/boost/container_hash/hash_fwd.hpp
@@ -14,7 +14,6 @@ namespace boost
 namespace container_hash
 {
 
-template<class Hash> struct hash_is_avalanching;
 template<class T> struct is_range;
 template<class T> struct is_contiguous_range;
 template<class T> struct is_unordered_range;
@@ -32,6 +31,8 @@ template<class It> std::size_t hash_range( It, It );
 
 template<class It> void hash_unordered_range( std::size_t&, It, It );
 template<class It> std::size_t hash_unordered_range( It, It );
+
+template<class Hash> struct hash_is_avalanching;
 
 } // namespace boost
 

--- a/include/boost/container_hash/hash_fwd.hpp
+++ b/include/boost/container_hash/hash_fwd.hpp
@@ -1,5 +1,5 @@
 // Copyright 2005-2009 Daniel James.
-// Copyright 2021, 2022 Peter Dimov.
+// Copyright 2021, 2022, 2025 Peter Dimov.
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -14,6 +14,7 @@ namespace boost
 namespace container_hash
 {
 
+template<class Hash> struct hash_is_avalanching;
 template<class T> struct is_range;
 template<class T> struct is_contiguous_range;
 template<class T> struct is_unordered_range;

--- a/include/boost/container_hash/hash_is_avalanching.hpp
+++ b/include/boost/container_hash/hash_is_avalanching.hpp
@@ -43,7 +43,7 @@ template<class Hash>
 struct hash_is_avalanching_impl<Hash, typename std::enable_if< ((void)Hash::is_avalanching, true) >::type>
 {
   // Hash::is_avalanching is not a type: we don't define value to produce
-  // compile error downstream
+  // a compile error downstream
 }; 
 
 } // namespace hash_detail

--- a/include/boost/container_hash/hash_is_avalanching.hpp
+++ b/include/boost/container_hash/hash_is_avalanching.hpp
@@ -48,14 +48,10 @@ struct hash_is_avalanching_impl<Hash, typename std::enable_if< ((void)Hash::is_a
 
 } // namespace hash_detail
 
-namespace container_hash
-{
-
 template<class Hash> struct hash_is_avalanching: hash_detail::hash_is_avalanching_impl<Hash>::type
 {
 };
 
-} // namespace container_hash
 } // namespace boost
 
 #endif // #ifndef BOOST_HASH_HASH_IS_AVALANCHING_HPP_INCLUDED

--- a/include/boost/container_hash/hash_is_avalanching.hpp
+++ b/include/boost/container_hash/hash_is_avalanching.hpp
@@ -1,0 +1,61 @@
+// Copyright 2025 Joaquin M Lopez Munoz.
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_HASH_HASH_IS_AVALANCHING_HPP_INCLUDED
+#define BOOST_HASH_HASH_IS_AVALANCHING_HPP_INCLUDED
+
+#include <type_traits>
+
+namespace boost
+{
+namespace hash_detail
+{
+
+template<class... Ts> struct make_void
+{
+    using type = void;
+};
+
+template<class... Ts> using void_t = typename make_void<Ts...>::type;
+
+template<class IsAvalanching> struct avalanching_value
+{
+    static constexpr bool value = IsAvalanching::value;
+};
+
+// may be explicitly marked as BOOST_DEPRECATED in the future
+template<> struct avalanching_value<void>
+{
+    static constexpr bool value = true;
+};
+
+template<class Hash, class = void> struct hash_is_avalanching_impl: std::false_type
+{
+};
+
+template<class Hash> struct hash_is_avalanching_impl<Hash, void_t<typename Hash::is_avalanching> >:
+    std::integral_constant<bool, avalanching_value<typename Hash::is_avalanching>::value>
+{
+};
+
+template<class Hash>
+struct hash_is_avalanching_impl<Hash, typename std::enable_if< ((void)Hash::is_avalanching, true) >::type>
+{
+  // Hash::is_avalanching is not a type: we don't define value to produce
+  // compile error downstream
+}; 
+
+} // namespace hash_detail
+
+namespace container_hash
+{
+
+template<class Hash> struct hash_is_avalanching: hash_detail::hash_is_avalanching_impl<Hash>::type
+{
+};
+
+} // namespace container_hash
+} // namespace boost
+
+#endif // #ifndef BOOST_HASH_HASH_IS_AVALANCHING_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018, 2019, 2021, 2022 Peter Dimov
+# Copyright 2018, 2019, 2021, 2022, 2025 Peter Dimov
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
@@ -7,6 +7,6 @@ include(BoostTestJamfile OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
 if(HAVE_BOOST_TEST)
 
 boost_test_jamfile(FILE Jamfile.v2
-  LINK_LIBRARIES Boost::container_hash Boost::core Boost::utility Boost::unordered)
+  LINK_LIBRARIES Boost::container_hash Boost::core Boost::utility)
 
 endif()

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,5 +1,5 @@
 # Copyright 2005-2012 Daniel James.
-# Copyright 2022 Peter Dimov
+# Copyright 2022, 2025 Peter Dimov
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
@@ -119,10 +119,9 @@ run is_described_class_test3.cpp
 run described_class_test.cpp
   : : : <warnings>extra ;
 
-run hash_is_avalanching_test.cpp
-  /boost/unordered//boost_unordered ;
-run hash_is_avalanching_test2.cpp
-  /boost/unordered//boost_unordered ;
+run hash_is_avalanching_test.cpp ;
+run hash_is_avalanching_test2.cpp ;
+run hash_is_avalanching_test3.cpp ;
 
 run hash_integral_test2.cpp ;
 

--- a/test/hash_is_avalanching_test.cpp
+++ b/test/hash_is_avalanching_test.cpp
@@ -12,7 +12,7 @@ enum my_char { min = 0, max = 255 };
 
 int main()
 {
-    using boost::container_hash::hash_is_avalanching;
+    using boost::hash_is_avalanching;
 
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::string> > ));
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::wstring> > ));

--- a/test/hash_is_avalanching_test.cpp
+++ b/test/hash_is_avalanching_test.cpp
@@ -6,26 +6,10 @@
 #include <boost/container_hash/hash_is_avalanching.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 #include <boost/config.hpp>
-#include <functional>
 #include <string>
 #include <type_traits>
 
 enum my_char { min = 0, max = 255 };
-
-struct X
-{
-    using is_avalanching = void;
-};
-
-struct Y
-{
-    using is_avalanching = std::true_type;
-};
-
-struct Z
-{
-    using is_avalanching = std::false_type;
-};
 
 int main()
 {
@@ -57,11 +41,6 @@ int main()
 #else
     BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< boost::hash<std::basic_string<my_char> > > ));
 #endif
-
-    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< std::hash<std::string > > ));
-    BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< X > ));
-    BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< Y > ));
-    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< Z > ));
 
     return boost::report_errors();
 }

--- a/test/hash_is_avalanching_test.cpp
+++ b/test/hash_is_avalanching_test.cpp
@@ -7,7 +7,6 @@
 #include <boost/core/lightweight_test_trait.hpp>
 #include <boost/config.hpp>
 #include <string>
-#include <type_traits>
 
 enum my_char { min = 0, max = 255 };
 

--- a/test/hash_is_avalanching_test.cpp
+++ b/test/hash_is_avalanching_test.cpp
@@ -1,18 +1,35 @@
-// Copyright 2022 Peter Dimov.
+// Copyright 2022, 2025 Peter Dimov.
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/container_hash/hash.hpp>
+#include <boost/container_hash/hash_is_avalanching.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
-#include <boost/unordered/hash_traits.hpp>
 #include <boost/config.hpp>
+#include <functional>
 #include <string>
+#include <type_traits>
 
 enum my_char { min = 0, max = 255 };
 
+struct X
+{
+    using is_avalanching = void;
+};
+
+struct Y
+{
+    using is_avalanching = std::true_type;
+};
+
+struct Z
+{
+    using is_avalanching = std::false_type;
+};
+
 int main()
 {
-    using boost::unordered::hash_is_avalanching;
+    using boost::container_hash::hash_is_avalanching;
 
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::string> > ));
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::wstring> > ));
@@ -40,6 +57,11 @@ int main()
 #else
     BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< boost::hash<std::basic_string<my_char> > > ));
 #endif
+
+    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< std::hash<std::string > > ));
+    BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< X > ));
+    BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< Y > ));
+    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< Z > ));
 
     return boost::report_errors();
 }

--- a/test/hash_is_avalanching_test2.cpp
+++ b/test/hash_is_avalanching_test2.cpp
@@ -15,7 +15,6 @@ int main() {}
 
 #else
 
-#include <boost/unordered/hash_traits.hpp>
 #include <string_view>
 
 enum my_char { min = 0, max = 255 };

--- a/test/hash_is_avalanching_test2.cpp
+++ b/test/hash_is_avalanching_test2.cpp
@@ -21,7 +21,7 @@ enum my_char { min = 0, max = 255 };
 
 int main()
 {
-    using boost::container_hash::hash_is_avalanching;
+    using boost::hash_is_avalanching;
 
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::string_view> > ));
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::wstring_view> > ));

--- a/test/hash_is_avalanching_test2.cpp
+++ b/test/hash_is_avalanching_test2.cpp
@@ -1,8 +1,9 @@
-// Copyright 2022 Peter Dimov.
+// Copyright 2022, 2025 Peter Dimov.
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/container_hash/hash.hpp>
+#include <boost/container_hash/hash_is_avalanching.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 #include <boost/config.hpp>
 #include <boost/config/pragma_message.hpp>
@@ -21,7 +22,7 @@ enum my_char { min = 0, max = 255 };
 
 int main()
 {
-    using boost::unordered::hash_is_avalanching;
+    using boost::container_hash::hash_is_avalanching;
 
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::string_view> > ));
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< boost::hash<std::wstring_view> > ));

--- a/test/hash_is_avalanching_test3.cpp
+++ b/test/hash_is_avalanching_test3.cpp
@@ -4,8 +4,6 @@
 
 #include <boost/container_hash/hash_is_avalanching.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
-#include <functional>
-#include <string>
 #include <type_traits>
 
 struct X
@@ -23,14 +21,18 @@ struct Z
     using is_avalanching = std::false_type;
 };
 
+struct W
+{
+};
+
 int main()
 {
     using boost::container_hash::hash_is_avalanching;
 
-    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< std::hash<std::string > > ));
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< X > ));
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< Y > ));
     BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< Z > ));
+    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< W > ));
 
     return boost::report_errors();
 }

--- a/test/hash_is_avalanching_test3.cpp
+++ b/test/hash_is_avalanching_test3.cpp
@@ -27,7 +27,7 @@ struct W
 
 int main()
 {
-    using boost::container_hash::hash_is_avalanching;
+    using boost::hash_is_avalanching;
 
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< X > ));
     BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< Y > ));

--- a/test/hash_is_avalanching_test3.cpp
+++ b/test/hash_is_avalanching_test3.cpp
@@ -1,0 +1,36 @@
+// Copyright 2025 Joaquin M Lopez Munoz.
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/container_hash/hash_is_avalanching.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+#include <functional>
+#include <string>
+#include <type_traits>
+
+struct X
+{
+    using is_avalanching = void;
+};
+
+struct Y
+{
+    using is_avalanching = std::true_type;
+};
+
+struct Z
+{
+    using is_avalanching = std::false_type;
+};
+
+int main()
+{
+    using boost::container_hash::hash_is_avalanching;
+
+    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< std::hash<std::string > > ));
+    BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< X > ));
+    BOOST_TEST_TRAIT_TRUE(( hash_is_avalanching< Y > ));
+    BOOST_TEST_TRAIT_FALSE(( hash_is_avalanching< Z > ));
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
This is part 1 of the process of migrating `hash_is_avalanching` from Boost.Unordered to Boost.ContainerHash; part 2 will redefine `boost::unordered::hash_is_avalanching` as a using declaration of `boost::container_hash::hash_is_avalanching` and deprecate `<boost/unordered/hash_traits.hpp>`.